### PR TITLE
Use cc crate for building c code

### DIFF
--- a/blip_buf-sys/Cargo.toml
+++ b/blip_buf-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blip_buf-sys"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Mathijs van de Nes <git@mathijs.vd-nes.nl>"]
 build = "build.rs"
 license = "MIT"
@@ -17,4 +17,4 @@ path = "lib.rs"
 libc = "0.2"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"

--- a/blip_buf-sys/build.rs
+++ b/blip_buf-sys/build.rs
@@ -1,8 +1,7 @@
-extern crate gcc;
-
-use std::env;
+extern crate cc;
 
 fn main() {
-    gcc::compile_library("libblip_buf.a", &["blip_buf.c"]);
-    println!("cargo:root={}", env::var("OUT_DIR").unwrap());
+    cc::Build::new()
+        .file("blip_buf.c")
+        .compile("blip_buf");
 }


### PR DESCRIPTION
The gcc crate is old and deprecated and apparently has trouble building arm64 targets on Apple Silicon Macs. Replacing it with the newer cc crate solves the issue.